### PR TITLE
[CU-86dvyqq2k] Generic Table Component For Travel Agency FE

### DIFF
--- a/resources/js/domains/guest/screens/Cities.tsx
+++ b/resources/js/domains/guest/screens/Cities.tsx
@@ -1,11 +1,79 @@
-import { CitiesTable } from "~/shared/components/cities/CitiesTable";
+// import { CitiesTable } from "~/shared/components/cities/CitiesTable";
+import { title } from "process";
+import { useEffect, useState } from "react";
+
+import { City, CityFilters } from "~/api";
+import { getCities } from "~/api/cities";
+import { ColumnProps } from "~/shared.types";
+import { Table } from "~/ui/common/Table";
+
+type FilterName = keyof CityFilters;
 
 export const Cities = () => {
+  const [cities, setCities] = useState<City[]>([]);
+  // // const [sort, setSort] = useState("");
+  // // const [order, setOrder] = useState<SortDirectionType>(SortDirection.asc);
+
+  // const [filters, setFilters] = useState<CityFilters>({});
+
+  // function isFilter(propertyName: string): propertyName is FilterName {
+  //   return propertyName in filters;
+  // }
+
+  // const buildQueryParams = () => {
+  //   const params = new URLSearchParams();
+
+  //   Object.keys(filters).forEach((key) => {
+  //     if (isFilter(key)) {
+  //       params.append(`filter[${key}]`, filters[key] ? `${filters[key]}` : "");
+  //     }
+  //   });
+
+  //   if (sort) params.append("sort", order === "asc" ? sort : `-${sort}`);
+
+  //   params.append("page", pageNumber.toString());
+
+  //   return params.toString();
+  // };
+
+  const loadCities = async () => {
+    try {
+      // const queryParams = buildQueryParams();
+      // const res = await getCities(queryParams);
+      const res = await getCities("");
+      setCities(res.data);
+      // setPagination(res.pagination);
+    } catch (error: any) {
+      console.error("Error obtaining cities:", error.message);
+    } finally {
+      // setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCities();
+  });
+
+  const columns: Array<ColumnProps<City>> = [
+    {
+      key: "name",
+      title: "Name",
+    },
+    {
+      key: "departureFlightsCount",
+      title: "Departure Flights",
+    },
+    {
+      key: "arrivalFlightsCount",
+      title: "Arrival Flights",
+    },
+  ];
+
   return (
     <div className="prose text-white lg:prose-xl md:p-10">
       <h1>Cities</h1>
 
-      <CitiesTable />
+      <Table data={cities} columns={columns} />
     </div>
   );
 };

--- a/resources/js/modals/City/EditCityModal.tsx
+++ b/resources/js/modals/City/EditCityModal.tsx
@@ -6,7 +6,7 @@ import type { ModalProps } from "~/shared.types";
 import { Button, Modal } from "~/ui";
 
 interface CityModalProps extends ModalProps {
-  city: City | null;
+  city: City | undefined;
 }
 
 export const EditCityModal = ({ show, onClose, city }: CityModalProps) => {

--- a/resources/js/shared.types.ts
+++ b/resources/js/shared.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ReactElement } from "react";
 import { z } from "zod";
 
 export type SVGProps = ComponentPropsWithoutRef<"svg">;
@@ -16,3 +16,9 @@ export const flightFormSchema = z.object({
   arrivalTime: z.string(),
 });
 export type FlightFormValues = z.infer<typeof flightFormSchema>;
+
+export interface ColumnProps<T> {
+  key: string;
+  title: string;
+  // render?: (column: ColumnProps<T>, item: T) => ReactElement;
+}

--- a/resources/js/shared/components/cities/CitiesTable.tsx
+++ b/resources/js/shared/components/cities/CitiesTable.tsx
@@ -24,7 +24,7 @@ export const CitiesTable = () => {
   const [filters, setFilters] = useState<CityFilters>({});
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
-  const [selectedCity, setSelectedCity] = useState<City | null>(null);
+  const [selectedCity, setSelectedCity] = useState<City>();
   const [pageNumber, setPageNumber] = useState(FIRST_PAGE);
 
   function isFilter(propertyName: string): propertyName is FilterName {

--- a/resources/js/ui/common/Table.tsx
+++ b/resources/js/ui/common/Table.tsx
@@ -1,0 +1,114 @@
+import { City } from "~/api";
+import { ColumnProps } from "~/shared.types";
+
+const FIRST_PAGE = 1;
+
+type Props<T> = {
+  columns: Array<ColumnProps<T>>;
+  data?: T[];
+};
+
+export function Table<T>({ data, columns }: Props<T>) {
+  const headers = columns.map((col) => <th>{col.title}</th>);
+
+  const rows = !data?.length ? (
+    <tr>
+      <td colSpan={columns.length} className="text-center">
+        No data
+      </td>
+    </tr>
+  ) : (
+    data?.map((row, index) => {
+      return (
+        <tr key={`row-${index}`}>
+          {columns.map((column, index2) => {
+            // const value = column.render
+            //   ? column.render(column, row as T)
+            //   : (row[column.key as keyof typeof row] as string);
+
+            const value = row[column.key as keyof typeof City];
+
+            return <td key={`cell-${index2}`}>{value}</td>;
+          })}
+        </tr>
+      );
+    })
+  );
+
+  return (
+    <>
+      <table className="w-full whitespace-nowrap text-left">
+        <thead className="border-b border-white/10 text-sm leading-6 text-black">
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Arrival Flights</th>
+            <th>Departure Flights</th>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {cities.map((city) => (
+            <tr key={city.id} className="text-black">
+              <td>{city.id}</td>
+              <td>{city.name}</td>
+              <td>{city.arrival_flights_count}</td>
+              <td>{city.departure_flights_count}</td>
+              <td>
+                <Button
+                  variant="secondary"
+                  onClick={() => handleEditClick(city)}
+                >
+                  Edit
+                </Button>
+              </td>
+              <td>
+                <Button
+                  variant="secondary"
+                  onClick={() => handleDeleteClick(city)}
+                >
+                  Delete
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2">
+        {pagination && (
+          <Button
+            variant="primary"
+            onClick={() => {
+              setPageNumber((prev) => prev - 1);
+              loadCities();
+            }}
+            disabled={pageNumber === 1}
+          >
+            Previous
+          </Button>
+        )}
+        {pagination && (
+          <>
+            <Button
+              variant="primary"
+              onClick={() => {
+                setPageNumber((prev) => prev + 1);
+                loadCities();
+              }}
+              disabled={pageNumber === pagination.totalPages}
+            >
+              Next
+            </Button>
+            <div className="text-black">
+              <span className="text-sm">
+                showing {pagination.count} of {pagination.total} cities. Page{" "}
+                {pageNumber} of {pagination.totalPages}
+              </span>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
# ⚡ Generic Table Component For Travel Agency FE - [CU-86dvyqq2k](https://app.clickup.com/t/86dvyqq2k) ⚡

## 💻 What type of change is this?

- [x] 💎 Feature

## ⭐ Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
Example:
-->

For more background, see ticket **CU-86dvyqq2k[in-progress].**

<!--
ONLY ADD SECTION IF A NEW PACKAGE IS ADDED
### Requires
This pr requires the following packages to be installed:
- `package1`
- `package2`
The packages are used for `reason1` and `reason2`.

Because of this, you must run `npm i` before starting.
-->

## 📷 Screenshots

<!--
Please include before AND after screenshots of the change, or proof of test about your branch
-->

### Before



### After




## 💬 Comments

<!--
Please describe any known issues, bugs, or unintended consequences with this change. Also, please include any additional comments you feel are relevant to the reviewer.

Ex:
This pr is blocked by #1234.
Im awaiting backend changes to be merged before I can complete this, etc.
This
-->

## ✅ Checklist
### To review
- [ ] I have tested this change locally in multiple screen sizes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If my task include an endpoint, I add the endpoint to Hopscotch/Postman Project
- [ ] Any dependent changes have been merged and published in downstream modules
